### PR TITLE
There should be a space before the </s> tag for assistant messages

### DIFF
--- a/inference/sagemaker-notebook.ipynb
+++ b/inference/sagemaker-notebook.ipynb
@@ -287,7 +287,7 @@
     "        elif message[\"role\"] == \"user\":\n",
     "            conversation.append(message[\"content\"].strip())\n",
     "        else:\n",
-    "            conversation.append(f\" [/INST] {message['content'].strip()}</s><s>[INST] \")\n",
+    "            conversation.append(f\" [/INST] {message['content'].strip()} </s><s>[INST] \")\n",
     "\n",
     "    return startPrompt + \"\".join(conversation) + endPrompt\n",
     "  \n",


### PR DESCRIPTION
According to the [Hugging Face Llama 2 prompt template guide](https://huggingface.co/blog/llama2), there should be a space after the assistant message, right before the `</s>` tag.